### PR TITLE
Grab edges between de-orphaning nodes in expand_context

### DIFF
--- a/xg.cpp
+++ b/xg.cpp
@@ -982,7 +982,8 @@ void XG::expand_context(Graph& g, size_t steps) const {
         }
         to_visit = to_visit_next;
     }
-    // then add connected nodes
+    // then add connected nodes so we don't have orphan edges
+    to_visit.clear();
     for (auto& e : edges) {
         auto& edge = e.second;
         // get missing nodes
@@ -991,14 +992,36 @@ void XG::expand_context(Graph& g, size_t steps) const {
             Node* np = g.add_node();
             nodes[f] = np;
             *np = node(f);
+            to_visit.insert(f);
         }
         int64_t t = edge->to();
         if (nodes.find(t) == nodes.end()) {
             Node* np = g.add_node();
             nodes[t] = np;
             *np = node(t);
+            to_visit.insert(t);
         }
     }
+    
+    // add in the edges between the newly added nodes. All their other edges
+    // that wou;dn't be orphaned have been accounted for.
+    for (auto& id : to_visit) {
+        for (auto& edge : edges_of(id)) {
+            if(!to_visit.count(edge.from()) || !to_visit.count(edge.to())) {
+                // this edge would be orphaned or should already be there.
+                continue;
+            }
+        
+            auto sides = make_pair(Side(edge.from(), edge.from_start()),
+                                   Side(edge.to(), edge.to_end()));
+            if (edges.find(sides) == edges.end()) {
+                // Add the edge if we don't have it
+                Edge* ep = g.add_edge(); *ep = edge;
+                edges[sides] = ep;
+            }
+        }
+    }
+    
     add_paths_to_graph(nodes, g);
 }
 

--- a/xg.hpp
+++ b/xg.hpp
@@ -89,6 +89,9 @@ public:
     void neighborhood(int64_t id, size_t steps, Graph& g) const;
     //void for_path_range(string& name, int64_t start, int64_t stop, function<void(Node)> lambda);
     void get_path_range(string& name, int64_t start, int64_t stop, Graph& g) const;
+    // Walk out the given number of steps from the nodes and edges already in
+    // the graph, adding in nodes and their attached edges. Does not produce
+    // orphan edges.
     void expand_context(Graph& g, size_t steps) const;
     void get_connected_nodes(Graph& g) const;
     void get_id_range(int64_t id1, int64_t id2, Graph& g) const;


### PR DESCRIPTION
I'm not sure where the otherwise orphan edges were being squirreled away in the old index, but this brings the behavior of `vg find` on a node range on top of the xg index more in line with what it was on a vg index.
