### PR TITLE
query a specific character in the graph without building a vg::Node

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@ void help_main(char** argv) {
          << "    -n, --node ID        graph neighborhood around node with ID" << endl
          << "    -c, --context N      steps of context to extract when building neighborhood" << endl
          << "    -s, --node-seq ID    provide node sequence for ID" << endl
+         << "    -P, --pos-char POS   give the character at a given position in the graph" << endl
          << "    -f, --edges-from ID  list edges from node with ID" << endl
          << "    -t, --edges-to ID    list edges to node with ID" << endl
          << "    -O, --edges-of ID    list all edges related to node with ID" << endl
@@ -51,6 +52,7 @@ int main(int argc, char** argv) {
     bool edges_on_start = false;
     bool edges_on_end = false;
     bool node_sequence = false;
+    string pos_for_char;
     int context_steps = 0;
     bool node_context = false;
     string target;
@@ -68,6 +70,7 @@ int main(int argc, char** argv) {
                 {"out", required_argument, 0, 'o'},
                 {"in", required_argument, 0, 'i'},
                 {"node", required_argument, 0, 'n'},
+                {"pos-char", required_argument, 0, 'P'},
                 //{"range", required_argument, 0, 'r'},
                 {"context", required_argument, 0, 'c'},
                 {"edges-from", required_argument, 0, 'f'},
@@ -84,7 +87,7 @@ int main(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hv:o:i:f:t:s:c:n:p:DTO:S:E:V",
+        c = getopt_long (argc, argv, "hv:o:i:f:t:s:c:n:p:DTO:S:E:VP:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -160,6 +163,10 @@ int main(int argc, char** argv) {
         case 'p':
             target = optarg;
             break;
+
+        case 'P':
+            pos_for_char = optarg;
+            break;
             
         case 'h':
         case '?':
@@ -211,6 +218,15 @@ int main(int argc, char** argv) {
     // queries
     if (node_sequence) {
         cout << node_id << ": " << graph->node_sequence(node_id) << endl;
+    }
+    if (!pos_for_char.empty()) {
+        // extract the position from the string
+        int64_t id;
+        bool is_rev;
+        size_t off;
+        extract_pos(pos_for_char, id, is_rev, off);
+        // then pick it up from the graph
+        cout << graph->pos_char(id, is_rev, off) << endl;
     }
     if (edges_from) {
         vector<Edge> edges = graph->edges_from(node_id);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,8 @@ void help_main(char** argv) {
          << "    -n, --node ID        graph neighborhood around node with ID" << endl
          << "    -c, --context N      steps of context to extract when building neighborhood" << endl
          << "    -s, --node-seq ID    provide node sequence for ID" << endl
-         << "    -P, --pos-char POS   give the character at a given position in the graph" << endl
+         << "    -P, --char POS       give the character at a given position in the graph" << endl
+         << "    -F, --substr POS:LEN extract the substr of LEN on the node at the position" << endl
          << "    -f, --edges-from ID  list edges from node with ID" << endl
          << "    -t, --edges-to ID    list edges to node with ID" << endl
          << "    -O, --edges-of ID    list all edges related to node with ID" << endl
@@ -53,6 +54,7 @@ int main(int argc, char** argv) {
     bool edges_on_end = false;
     bool node_sequence = false;
     string pos_for_char;
+    string pos_for_substr;
     int context_steps = 0;
     bool node_context = false;
     string target;
@@ -70,7 +72,8 @@ int main(int argc, char** argv) {
                 {"out", required_argument, 0, 'o'},
                 {"in", required_argument, 0, 'i'},
                 {"node", required_argument, 0, 'n'},
-                {"pos-char", required_argument, 0, 'P'},
+                {"char", required_argument, 0, 'P'},
+                {"substr", required_argument, 0, 'F'},
                 //{"range", required_argument, 0, 'r'},
                 {"context", required_argument, 0, 'c'},
                 {"edges-from", required_argument, 0, 'f'},
@@ -87,7 +90,7 @@ int main(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hv:o:i:f:t:s:c:n:p:DTO:S:E:VP:",
+        c = getopt_long (argc, argv, "hv:o:i:f:t:s:c:n:p:DTO:S:E:VP:F:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -168,6 +171,10 @@ int main(int argc, char** argv) {
             pos_for_char = optarg;
             break;
             
+        case 'F':
+            pos_for_substr = optarg;
+            break;
+            
         case 'h':
         case '?':
             help_main(argv);
@@ -228,6 +235,15 @@ int main(int argc, char** argv) {
         // then pick it up from the graph
         cout << graph->pos_char(id, is_rev, off) << endl;
     }
+    if (!pos_for_substr.empty()) {
+        int64_t id;
+        bool is_rev;
+        size_t off;
+        size_t len;
+        extract_pos_substr(pos_for_substr, id, is_rev, off, len);
+        cout << graph->pos_substr(id, is_rev, off, len) << endl;
+    }
+    
     if (edges_from) {
         vector<Edge> edges = graph->edges_from(node_id);
         for (auto& edge : edges) {

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -66,6 +66,7 @@ public:
     size_t max_node_rank(void) const;
     Node node(int64_t id) const; // gets node sequence
     string node_sequence(int64_t id) const;
+    char pos_char(int64_t id, bool is_rev, size_t off); // character at position
     vector<Edge> edges_of(int64_t id) const;
     vector<Edge> edges_to(int64_t id) const;
     vector<Edge> edges_from(int64_t id) const;
@@ -168,7 +169,7 @@ private:
     bit_vector s_bv; // node positions in siv
     rank_support_v<1> s_bv_rank;
     bit_vector::select_1_type s_bv_select;
-    // compressed version, unused...
+    // compressed version
     rrr_vector<> s_cbv;
     rrr_vector<>::rank_1_type s_cbv_rank;
     rrr_vector<>::select_1_type s_cbv_select;
@@ -340,6 +341,13 @@ bool depart_by_reverse(const Edge& e, int64_t node_id, bool node_is_reverse);
 
 // Make an edge from its fields (generally for comparison)
 Edge make_edge(int64_t from, bool from_start, int64_t to, bool to_end);
+
+// Helpers for when we're picking up parts of the graph without returning full Node objects
+char reverse_complement(const char& c);
+string reverse_complement(const string& seq);
+
+// Position parsing helper for CLI
+void extract_pos(const string& pos_str, int64_t& id, bool& is_rev, size_t& off);
 
 }
 

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -66,7 +66,9 @@ public:
     size_t max_node_rank(void) const;
     Node node(int64_t id) const; // gets node sequence
     string node_sequence(int64_t id) const;
-    char pos_char(int64_t id, bool is_rev, size_t off); // character at position
+    size_t node_length(int64_t id) const;
+    char pos_char(int64_t id, bool is_rev, size_t off) const; // character at position
+    string pos_substr(int64_t id, bool is_rev, size_t off, size_t len = 0) const; // substring in range
     vector<Edge> edges_of(int64_t id) const;
     vector<Edge> edges_to(int64_t id) const;
     vector<Edge> edges_from(int64_t id) const;
@@ -346,8 +348,9 @@ Edge make_edge(int64_t from, bool from_start, int64_t to, bool to_end);
 char reverse_complement(const char& c);
 string reverse_complement(const string& seq);
 
-// Position parsing helper for CLI
+// Position parsing helpers for CLI
 void extract_pos(const string& pos_str, int64_t& id, bool& is_rev, size_t& off);
+void extract_pos_substr(const string& pos_str, int64_t& id, bool& is_rev, size_t& off, size_t& len);
 
 }
 

--- a/test/t/02_query.t
+++ b/test/t/02_query.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../bash-tap
 
 PATH=../bin:$PATH # for xg
 
-plan tests 18
+plan tests 20
 
 xg -v data/z.vg -o z.idx 2>/dev/null
 is $(xg -i z.idx -s 10331 | cut -f 2 -d\ ) "CAGCAGTGGAGCAGAAACAGAGGAGATGACACCATGGGGTAAGCACAGTC" "graph can be queried to obtain node labels"
@@ -19,8 +19,10 @@ xg -v data/l.vg -o l.idx 2>/dev/null
 xg -i l.idx -p z:0-100 >/dev/null
 is $? 0 "path queries can exceed reference length without error"
 
-is $(xg -P 4:5 -i l.idx) "C" "characters on the forward strand may be queried"
-is $(xg -P 4:-5 -i l.idx) "G" "characters on the reverse strand may be queried"
+is $(xg -P 3:0 -i l.idx) "T" "characters on the forward strand may be queried"
+is $(xg -P 3:-0 -i l.idx) "A" "characters on the reverse strand may be queried"
+is $(xg -P 4:0 -i l.idx | head -c 1) $(xg -F 4:0:0 -i l.idx | head -c 1) "obtaining the node sequence works as expected on the forward strand"
+is $(xg -P 4:-0 -i l.idx | head -c 1) $(xg -F 4:-0:0 -i l.idx | head -c 1)  "obtaining the node sequence works as expected on the reverse strand"
 
 is $(xg -i l.idx -p z:0-10 | md5sum | cut -f 1 -d\ ) "ee265e344d67e72b43589934e5257a9b" "paths can be queried from the small graph"
 is $(xg -i l.idx -p z:0-100 -c 2 | md5sum | cut -f 1 -d\ ) "76ee1e231d3985d63dbf0abe083b4805" "the entire graph can be extracted with a long query and context"

--- a/test/t/02_query.t
+++ b/test/t/02_query.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../bash-tap
 
 PATH=../bin:$PATH # for xg
 
-plan tests 16
+plan tests 18
 
 xg -v data/z.vg -o z.idx 2>/dev/null
 is $(xg -i z.idx -s 10331 | cut -f 2 -d\ ) "CAGCAGTGGAGCAGAAACAGAGGAGATGACACCATGGGGTAAGCACAGTC" "graph can be queried to obtain node labels"
@@ -18,6 +18,9 @@ rm -f z.idx
 xg -v data/l.vg -o l.idx 2>/dev/null
 xg -i l.idx -p z:0-100 >/dev/null
 is $? 0 "path queries can exceed reference length without error"
+
+is $(xg -P 4:5 -i l.idx) "C" "characters on the forward strand may be queried"
+is $(xg -P 4:-5 -i l.idx) "G" "characters on the reverse strand may be queried"
 
 is $(xg -i l.idx -p z:0-10 | md5sum | cut -f 1 -d\ ) "ee265e344d67e72b43589934e5257a9b" "paths can be queried from the small graph"
 is $(xg -i l.idx -p z:0-100 -c 2 | md5sum | cut -f 1 -d\ ) "76ee1e231d3985d63dbf0abe083b4805" "the entire graph can be extracted with a long query and context"


### PR DESCRIPTION
I'll also push a substring getter into this. I need it for efficiently converting exact matches from GCSA2 into alignment objects.
