### PR TITLE
Allow building from a callback

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -60,7 +60,7 @@ XG::XG(function<void(function<void(Graph&)>)> get_chunks)
       node_count(0),
       edge_count(0),
       path_count(0) {
-    from_callback(std::move(get_chunks));
+    from_callback(get_chunks);
 }
 
 XG::~XG(void) {
@@ -356,8 +356,8 @@ void XG::from_stream(istream& in, bool validate_graph, bool print_graph) {
     from_callback([&](function<void(Graph&)> handle_chunk) {
         // TODO: should I be bandying about function references instead of
         // function objects here?
-        stream::for_each(in, std::move(handle_chunk));
-    });
+        stream::for_each(in, handle_chunk);
+    }, validate_graph, print_graph);
 }
 
 void XG::from_graph(Graph& graph, bool validate_graph, bool print_graph) {
@@ -365,7 +365,7 @@ void XG::from_graph(Graph& graph, bool validate_graph, bool print_graph) {
     from_callback([&](function<void(Graph&)> handle_chunk) {
         // There's only one chunk in this case.
         handle_chunk(graph);
-    });
+    }, validate_graph, print_graph);
 
 }
 
@@ -1974,7 +1974,7 @@ list<Path> XG::extract_threads() const {
 #ifdef VERBOSE_DEBUG
                 cerr << "At side " << side << endl;
                 
-                cerr << "Want B group " << side - 2 << " of " << nonconst_bs_iv->rank(nonconst_bs_iv->size(), BS_SEPARATOR) << " at " << nonconst_bs_iv->size() << endl;
+                cerr << "Want B group " << side - 2 << " of " << nonconst_bs_iv.rank(nonconst_bs_iv.size(), BS_SEPARATOR) << " at " << nonconst_bs_iv.size() << endl;
 #endif
                 // Work out where we go
                 
@@ -1982,8 +1982,8 @@ list<Path> XG::extract_threads() const {
                 int64_t edge_index = nonconst_bs_iv.at(nonconst_bs_iv.select(side - 2, BS_SEPARATOR) + 1 + offset);
                 
 #ifdef VERBOSE_DEBUG
-                cerr << "Group starts at " << nonconst_bs_iv->select(side - 2, BS_SEPARATOR) << endl;
-                int64_t outbound_count = ((side - 2 == nonconst_bs_iv->rank(nonconst_bs_iv->size(), BS_SEPARATOR) - 1) ? nonconst_bs_iv->size() : nonconst_bs_iv->select(side - 2 + 1, BS_SEPARATOR)) - nonconst_bs_iv->select(side - 2, BS_SEPARATOR);
+                cerr << "Group starts at " << nonconst_bs_iv.select(side - 2, BS_SEPARATOR) << endl;
+                int64_t outbound_count = ((side - 2 == nonconst_bs_iv.rank(nonconst_bs_iv.size(), BS_SEPARATOR) - 1) ? nonconst_bs_iv.size() : nonconst_bs_iv.select(side - 2 + 1, BS_SEPARATOR)) - nonconst_bs_iv.select(side - 2, BS_SEPARATOR);
                 cerr << "Local B entry " << offset << " of " << outbound_count << endl;
                 assert(offset < outbound_count);
 #endif

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1272,6 +1272,11 @@ size_t XG::path_rank(const string& name) const {
         cerr << "multiple hits for " << query << endl;
         assert(false);
     }
+    if(occs.size() == 0) {
+        // This path does not exist. Give back 0, which can never be a real path
+        // rank.
+        return 0;
+    }
     //cerr << "path named " << name << " is at " << occs[0] << endl;
     return pn_bv_rank(occs[0])+1; // step past '#'
 }

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1264,6 +1264,26 @@ size_t XG::edge_rank_as_entity(const Edge& edge) const {
     }
 }
 
+Path XG::path(const string& name) const {
+    // Extract a whole path by name
+    
+    // First find the XGPath we're using to store it.
+    XGPath& xgpath = *(paths[path_rank(name)-1]);
+    
+    // Make a new path to fill in
+    Path to_return;
+    // Fill in the name
+    to_return.set_name(name);
+    
+    for(size_t i = 0; i < xgpath.member_count; i++) {
+        // For everything on the XGPath, put a Mapping on the real path.
+        *(to_return.add_mapping()) = xgpath.mapping(i);
+    }
+    
+    return to_return;
+    
+}
+
 size_t XG::path_rank(const string& name) const {
     // find the name in the csa
     string query = start_marker + name + end_marker;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -50,7 +50,7 @@ public:
     void from_graph(Graph& graph, bool validate_graph = false, bool print_graph = false);
     // Load the graph by calling a function that calls us back with graph chunks.
     // The function passed in here is responsible for looping.
-    void from_callback(const function<void(function<void(Graph&)>)> get_chunks,
+    void from_callback(function<void(function<void(Graph&)>)> get_chunks,
         bool validate_graph = false, bool print_graph = false); 
     void build(map<int64_t, string>& node_label,
                map<Side, set<Side> >& from_to,

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -45,8 +45,13 @@ public:
     ~XG(void);
     XG(istream& in);
     XG(Graph& graph);
+    XG(function<void(function<void(Graph&)>)> get_chunks);
     void from_stream(istream& in, bool validate_graph = false, bool print_graph = false);
     void from_graph(Graph& graph, bool validate_graph = false, bool print_graph = false);
+    // Load the graph by calling a function that calls us back with graph chunks.
+    // The function passed in here is responsible for looping.
+    void from_callback(const function<void(function<void(Graph&)>)> get_chunks,
+        bool validate_graph = false, bool print_graph = false); 
     void build(map<int64_t, string>& node_label,
                map<Side, set<Side> >& from_to,
                map<Side, set<Side> >& to_from,

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -89,8 +89,13 @@ public:
     bool has_edge(int64_t id1, bool is_start, int64_t id2, bool is_end) const;
 
     Path path(const string& name) const;
+    // Returns the rank of the path with the given name, or 0 if no such path
+    // exists.
     size_t path_rank(const string& name) const;
+    // Returns the maxiumum rank of any existing path. A path does exist at this
+    // rank.
     size_t max_path_rank(void) const;
+    // Get the name of the path at the given rank. Ranks begin at 1.
     string path_name(size_t rank) const;
     vector<size_t> paths_of_entity(size_t rank) const;
     vector<size_t> paths_of_node(int64_t id) const;


### PR DESCRIPTION
This allows you to pass a function into xg, which xg will then call when it wants the chunks of your graph. You can then call _another_ callback to send your graph chunks into xg, and return when you run out of chunks.

This should make building xg indexes in vg easier, because you can just throw chunks at it, instead of actually having to concatenate all your graphs into one stream or whatever.
