### PR TITLE
Dynamic serialization, optional thread inclusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ sdsl-lite/: $(CMAKE_BIN)
 
 DYNAMIC/:
 	git clone --recursive https://github.com/vgteam/DYNAMIC.git
-	cd DYNAMIC && git checkout cfd3ae7
+	cd DYNAMIC && git checkout 2a82bbf
 
 get-deps: $(CMAKE_BIN) protobuf/ sdsl-lite/ DYNAMIC/
 	cd protobuf && git checkout dfae9e3 && ./autogen.sh || ./autogen.sh && ./configure --prefix="$(CWD)" && make -j 8 && make install && export PATH=$(CWD)/bin:$$PATH

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,8 +29,9 @@ void help_main(char** argv) {
          << "    -t, --edges-to ID    list edges to node with ID" << endl
          << "    -O, --edges-of ID    list all edges related to node with ID" << endl
          << "    -S, --edges-on-start ID    list all edges on start of node with ID" << endl
-         << "    -E, --edges-on-end ID    list all edges on start of node with ID" << endl
+         << "    -E, --edges-on-end ID      list all edges on start of node with ID" << endl
          << "    -p, --path TARGET    gets the region of the graph @ TARGET (chr:start-end)" << endl
+         << "    -x, --extract-threads      extract succinct threads as paths" << endl
          << "    -D, --debug          show debugging output" << endl
          << "    -T, --text-output    write text instead of vg protobuf" << endl
          << "    -h, --help           this text" << endl;
@@ -61,6 +62,7 @@ int main(int argc, char** argv) {
     bool print_graph = false;
     bool text_output = false;
     bool validate_graph = false;
+    bool extract_threads = false;
     
     int c;
     optind = 1; // force optind past command positional argument
@@ -83,6 +85,7 @@ int main(int argc, char** argv) {
                 {"edges-on-end", required_argument, 0, 'E'},
                 {"node-seq", required_argument, 0, 's'},
                 {"path", required_argument, 0, 'p'},
+                {"extract-threads", no_argument, 0, 'x'},
                 {"debug", no_argument, 0, 'D'},
                 {"text-output", no_argument, 0, 'T'},
                 {"validate", no_argument, 0, 'V'},
@@ -90,7 +93,7 @@ int main(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hv:o:i:f:t:s:c:n:p:DTO:S:E:VP:F:",
+        c = getopt_long (argc, argv, "hv:o:i:f:t:s:c:n:p:DxTO:S:E:VP:F:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -118,6 +121,10 @@ int main(int argc, char** argv) {
 
         case 'T':
             text_output = true;
+            break;
+            
+        case 'x':
+            extract_threads = true;
             break;
 
         case 'i':
@@ -305,6 +312,33 @@ int main(int argc, char** argv) {
         } else {
             vector<Graph> gb = { g };
             stream::write_buffered(cout, gb, 0);
+        }
+    }
+    
+    if (extract_threads) {
+        
+    
+        size_t thread_number = 0;
+        for(Path& path : graph->extract_threads()) {
+            // Give each thread a name
+            path.set_name("_thread_" + to_string(thread_number++));
+            
+            // We need a Graph for serialization purposes. We do one chunk per
+            // thread in case the threads are long.
+            Graph g;
+            
+            *(g.add_path()) = path;
+            
+            // Dump the graph with its mappings. TODO: can we restrict these to
+            // mappings to nodes we have already pulled out? Or pull out the
+            // whole compressed graph?
+            if (text_output) {
+            to_text(cout, g);
+            } else {
+                vector<Graph> gb = { g };
+                stream::write_buffered(cout, gb, 0);
+            }
+            
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@ void help_main(char** argv) {
          << "    -E, --edges-on-end ID      list all edges on start of node with ID" << endl
          << "    -p, --path TARGET    gets the region of the graph @ TARGET (chr:start-end)" << endl
          << "    -x, --extract-threads      extract succinct threads as paths" << endl
+         << "    -r, --store-threads  store perfect match paths as succinct threads" << endl
          << "    -D, --debug          show debugging output" << endl
          << "    -T, --text-output    write text instead of vg protobuf" << endl
          << "    -h, --help           this text" << endl;
@@ -63,6 +64,7 @@ int main(int argc, char** argv) {
     bool text_output = false;
     bool validate_graph = false;
     bool extract_threads = false;
+    bool store_threads = false;
     
     int c;
     optind = 1; // force optind past command positional argument
@@ -86,6 +88,7 @@ int main(int argc, char** argv) {
                 {"node-seq", required_argument, 0, 's'},
                 {"path", required_argument, 0, 'p'},
                 {"extract-threads", no_argument, 0, 'x'},
+                {"store-threads", no_argument, 0, 'r'},
                 {"debug", no_argument, 0, 'D'},
                 {"text-output", no_argument, 0, 'T'},
                 {"validate", no_argument, 0, 'V'},
@@ -93,7 +96,7 @@ int main(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hv:o:i:f:t:s:c:n:p:DxTO:S:E:VP:F:",
+        c = getopt_long (argc, argv, "hv:o:i:f:t:s:c:n:p:DxrTO:S:E:VP:F:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -125,6 +128,10 @@ int main(int argc, char** argv) {
             
         case 'x':
             extract_threads = true;
+            break;
+            
+        case 'r':
+            store_threads = true;
             break;
 
         case 'i':
@@ -198,12 +205,12 @@ int main(int argc, char** argv) {
     if (in_name.empty()) assert(!vg_name.empty());
     if (vg_name == "-") {
         graph = new XG;
-        graph->from_stream(std::cin, validate_graph, print_graph);
+        graph->from_stream(std::cin, validate_graph, print_graph, store_threads);
     } else if (vg_name.size()) {
         ifstream in;
         in.open(vg_name.c_str());
         graph = new XG;
-        graph->from_stream(in, validate_graph, print_graph);
+        graph->from_stream(in, validate_graph, print_graph, store_threads);
     }
 
     if (in_name.size()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,6 +199,17 @@ int main(int argc, char** argv) {
         graph->from_stream(in, validate_graph, print_graph);
     }
 
+    if (in_name.size()) {
+        graph = new XG;
+        if (in_name == "-") {
+            graph->load(std::cin);
+        } else {
+            ifstream in;
+            in.open(in_name.c_str());
+            graph->load(in);
+        }
+    }
+
     if (out_name.size()) {
         if (out_name == "-") {
             graph->serialize(std::cout);
@@ -211,16 +222,7 @@ int main(int argc, char** argv) {
         }
     }
 
-    if (in_name.size()) {
-        graph = new XG;
-        if (in_name == "-") {
-            graph->load(std::cin);
-        } else {
-            ifstream in;
-            in.open(in_name.c_str());
-            graph->load(in);
-        }
-    }
+    
 
     // queries
     if (node_sequence) {

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2114,33 +2114,18 @@ void XG::extend_search(ThreadSearchState& state, const Path& t) const {
 }
 
 size_t serialize(XG::dynamic_int_vector* to_serialize, ostream& out, sdsl::structure_tree_node* child, const std::string name) {
-    size_t written = 0;
-    
-    // Convert the dynamic int vector to an SDSL int vector
-    int_vector<> converted(to_serialize->size());
-    
-    for(size_t i = 0; i < to_serialize->size(); i++) {
-        converted[i] = to_serialize->at(i);
-    }
-    
-    written += converted.serialize(out, child, name);
-    
-    return written;
+    // We just use the DYNAMIC serialization and ignore the SDSL parameters for now.
+    // TODO: do something smart with the SDSL structure tree   
+    return to_serialize->serialize(out);
 }
 
 XG::dynamic_int_vector* deserialize(istream& in) {
-
-    int_vector<> to_convert;
-
-    to_convert.load(in);
+    // We just load using the DYNAMIC deserialization code
+    XG::dynamic_int_vector* loaded = new XG::dynamic_int_vector;
     
-    XG::dynamic_int_vector* converted = new XG::dynamic_int_vector;
+    loaded->load(in);
     
-    for(size_t i = 0; i < to_convert.size(); i++) {
-        converted->push_back(to_convert[i]);
-    }
-    
-    return converted;
+    return loaded;
 }
 
 bool edges_equivalent(const Edge& e1, const Edge& e2) {

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -351,26 +351,26 @@ size_t XG::serialize(ostream& out, sdsl::structure_tree_node* s, std::string nam
     
 }
 
-void XG::from_stream(istream& in, bool validate_graph, bool print_graph) {
+void XG::from_stream(istream& in, bool validate_graph, bool print_graph, bool store_threads) {
 
     from_callback([&](function<void(Graph&)> handle_chunk) {
         // TODO: should I be bandying about function references instead of
         // function objects here?
         stream::for_each(in, handle_chunk);
-    }, validate_graph, print_graph);
+    }, validate_graph, print_graph, store_threads);
 }
 
-void XG::from_graph(Graph& graph, bool validate_graph, bool print_graph) {
+void XG::from_graph(Graph& graph, bool validate_graph, bool print_graph, bool store_threads) {
 
     from_callback([&](function<void(Graph&)> handle_chunk) {
         // There's only one chunk in this case.
         handle_chunk(graph);
-    }, validate_graph, print_graph);
+    }, validate_graph, print_graph, store_threads);
 
 }
 
 void XG::from_callback(function<void(function<void(Graph&)>)> get_chunks, 
-    bool validate_graph, bool print_graph) {
+    bool validate_graph, bool print_graph, bool store_threads) {
 
     // temporaries for construction
     map<int64_t, string> node_label;
@@ -429,7 +429,7 @@ void XG::from_callback(function<void(function<void(Graph&)>)> get_chunks,
     
     path_count = path_nodes.size();
 
-    build(node_label, from_to, to_from, path_nodes, validate_graph, print_graph);
+    build(node_label, from_to, to_from, path_nodes, validate_graph, print_graph, store_threads);
     
 }
 
@@ -438,7 +438,8 @@ void XG::build(map<int64_t, string>& node_label,
                map<Side, set<Side> >& to_from,
                map<string, map<int, Mapping>>& path_nodes,
                bool validate_graph,
-               bool print_graph) {
+               bool print_graph,
+               bool store_threads) {
 
     size_t entity_count = node_count + edge_count;
 #ifdef VERBOSE_DEBUG
@@ -674,50 +675,53 @@ void XG::build(map<int64_t, string>& node_label,
     util::assign(ep_bv_rank, rank_support_v<1>(&ep_bv));
     util::assign(ep_bv_select, bit_vector::select_1_type(&ep_bv));
 
+    if(store_threads) {
+
 #ifdef VERBOSE_DEBUG
-    cerr << "storing threads" << endl;
+        cerr << "storing threads" << endl;
 #endif
     
-    // Just store all the paths that are all perfect mappings as threads.
-    // We end up converting *back* into Path objects.
-    for (auto& pathpair : path_nodes) {
-        Path reconstructed;
-        
-        // Grab the name
-        reconstructed.set_name(pathpair.first);
-        
-        bool all_perfect = true;
-        
-        // Grab the Mappings, which are now sorted by rank
-        for (auto& m : pathpair.second) {
-            *reconstructed.add_mapping() = m.second;
+        // Just store all the paths that are all perfect mappings as threads.
+        // We end up converting *back* into Path objects.
+        for (auto& pathpair : path_nodes) {
+            Path reconstructed;
             
-            // Make sure the mapping is perfect
-            // TODO: handle offsets
-            if(m.second.edit_size() > 1) {
-                // Not a perfect mapping
-                all_perfect = false;
-                break;
-            } else if(m.second.edit_size() == 0) {
-                // Is a perfect mapping
-                continue;
-            } else {
-                // We have exactly one edit. Is it perfect?
-                auto edit = m.second.edit(0);
+            // Grab the name
+            reconstructed.set_name(pathpair.first);
+            
+            bool all_perfect = true;
+            
+            // Grab the Mappings, which are now sorted by rank
+            for (auto& m : pathpair.second) {
+                *reconstructed.add_mapping() = m.second;
                 
-                if(edit.from_length() != edit.to_length() || edit.sequence() != "") {
-                    // The edit calls for actual editing
+                // Make sure the mapping is perfect
+                // TODO: handle offsets
+                if(m.second.edit_size() > 1) {
+                    // Not a perfect mapping
                     all_perfect = false;
                     break;
+                } else if(m.second.edit_size() == 0) {
+                    // Is a perfect mapping
+                    continue;
+                } else {
+                    // We have exactly one edit. Is it perfect?
+                    auto edit = m.second.edit(0);
+                    
+                    if(edit.from_length() != edit.to_length() || edit.sequence() != "") {
+                        // The edit calls for actual editing
+                        all_perfect = false;
+                        break;
+                    }
                 }
             }
+            
+            if(all_perfect) {
+                // We actually want to insert this path as a thread
+                insert_thread(reconstructed);
+            }
+            
         }
-        
-        if(all_perfect) {
-            // We actually want to insert this path as a thread
-            insert_thread(reconstructed);
-        }
-        
     }
     
 
@@ -931,72 +935,75 @@ void XG::build(map<int64_t, string>& node_label,
             // check membership now for each entity in the path
         }
         
-        cerr << "validating threads" << endl;
+        if(store_threads) {
         
-        // How many thread orientations are in the index?
-        size_t threads_found = 0;
-        // And how many shoukd we have inserted?
-        size_t threads_expected = 0;
-        
-        for(auto path : extract_threads()) {
+            cerr << "validating threads" << endl;
+            
+            // How many thread orientations are in the index?
+            size_t threads_found = 0;
+            // And how many shoukd we have inserted?
+            size_t threads_expected = 0;
+            
+            for(auto path : extract_threads()) {
 #ifdef VERBOSE_DEBUG
-            cerr << "Path: ";
-            for(size_t i = 0; i < path.mapping_size(); i++) {
-                Mapping mapping = path.mapping(i);
-                cerr << mapping.position().node_id() * 2 + mapping.position().is_reverse() << "; ";
-            }
-            cerr << endl;
+                cerr << "Path: ";
+                for(size_t i = 0; i < path.mapping_size(); i++) {
+                    Mapping mapping = path.mapping(i);
+                    cerr << mapping.position().node_id() * 2 + mapping.position().is_reverse() << "; ";
+                }
+                cerr << endl;
 #endif
-            // Make sure we can search all the threads we find present in the index
-            assert(count_matches(path) > 0);
-            
-            threads_found++;
-        }
-        
-        for (auto& pathpair : path_nodes) {
-            Path reconstructed;
-            
-            // Grab the name
-            reconstructed.set_name(pathpair.first);
-            
-            bool all_perfect = true;
-            
-            // Grab the Mappings, which are now sorted by rank
-            for (auto& m : pathpair.second) {
-                *reconstructed.add_mapping() = m.second;
+                // Make sure we can search all the threads we find present in the index
+                assert(count_matches(path) > 0);
                 
-                // Make sure the mapping is perfect
-                // TODO: handle offsets
-                if(m.second.edit_size() > 1) {
-                    // Not a perfect mapping
-                    all_perfect = false;
-                    break;
-                } else if(m.second.edit_size() == 0) {
-                    // Is a perfect mapping
-                    continue;
-                } else {
-                    // We have exactly one edit. Is it perfect?
-                    auto edit = m.second.edit(0);
+                threads_found++;
+            }
+            
+            for (auto& pathpair : path_nodes) {
+                Path reconstructed;
+                
+                // Grab the name
+                reconstructed.set_name(pathpair.first);
+                
+                bool all_perfect = true;
+                
+                // Grab the Mappings, which are now sorted by rank
+                for (auto& m : pathpair.second) {
+                    *reconstructed.add_mapping() = m.second;
                     
-                    if(edit.from_length() != edit.to_length() || edit.sequence() != "") {
-                        // The edit calls for actual editing
+                    // Make sure the mapping is perfect
+                    // TODO: handle offsets
+                    if(m.second.edit_size() > 1) {
+                        // Not a perfect mapping
                         all_perfect = false;
                         break;
+                    } else if(m.second.edit_size() == 0) {
+                        // Is a perfect mapping
+                        continue;
+                    } else {
+                        // We have exactly one edit. Is it perfect?
+                        auto edit = m.second.edit(0);
+                        
+                        if(edit.from_length() != edit.to_length() || edit.sequence() != "") {
+                            // The edit calls for actual editing
+                            all_perfect = false;
+                            break;
+                        }
                     }
                 }
-            }
-            
-            if(all_perfect) {
-                // This path should have been inserted. Look for it.
-                assert(count_matches(reconstructed) > 0);
                 
-                threads_expected += 2;
+                if(all_perfect) {
+                    // This path should have been inserted. Look for it.
+                    assert(count_matches(reconstructed) > 0);
+                    
+                    threads_expected += 2;
+                }
+                
             }
             
+            // Make sure we have the right number of threads.
+            assert(threads_found == threads_expected);
         }
-        
-        // Make sure we have the right number of threads.
-        assert(threads_found == threads_expected);
 
         cerr << "graph ok" << endl;
     }

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -46,18 +46,19 @@ public:
     XG(istream& in);
     XG(Graph& graph);
     XG(function<void(function<void(Graph&)>)> get_chunks);
-    void from_stream(istream& in, bool validate_graph = false, bool print_graph = false);
-    void from_graph(Graph& graph, bool validate_graph = false, bool print_graph = false);
+    void from_stream(istream& in, bool validate_graph = false, bool print_graph = false, bool store_threads = false);
+    void from_graph(Graph& graph, bool validate_graph = false, bool print_graph = false, bool store_threads = false);
     // Load the graph by calling a function that calls us back with graph chunks.
     // The function passed in here is responsible for looping.
     void from_callback(function<void(function<void(Graph&)>)> get_chunks,
-        bool validate_graph = false, bool print_graph = false); 
+        bool validate_graph = false, bool print_graph = false, bool store_threads = false); 
     void build(map<int64_t, string>& node_label,
                map<Side, set<Side> >& from_to,
                map<Side, set<Side> >& to_from,
                map<string, map<int, Mapping>>& path_nodes,
                bool validate_graph,
-               bool print_graph);
+               bool print_graph,
+               bool store_threads);
     void load(istream& in);
     size_t serialize(std::ostream& out,
                      sdsl::structure_tree_node* v = NULL,

--- a/test/t/01_construction.t
+++ b/test/t/01_construction.t
@@ -5,12 +5,13 @@ BASH_TAP_ROOT=../bash-tap
 
 PATH=../bin:$PATH # for xg
 
-plan tests 10
+plan tests 11
 
 is $(xg -Vv data/l.vg 2>&1 | grep ok | wc -l) 1 "a small graph verifies"
 is $(xg -Vv data/lg.vg 2>&1 | grep ok | wc -l) 1 "a small graph with two named paths verifies"
-is $(xg -Vv data/l+.vg 2>&1 | grep ok | wc -l) 1 "node ids need not start at 1"
-is $(xg -Vv data/z.vg 2>&1 | grep ok | wc -l) 1 "a 1mb graph verifies"
+is $(xg -Vrv data/lg.vg 2>&1 | grep ok | wc -l) 1 "a small graph with threads verifies"
+is $(xg -Vrv data/l+.vg 2>&1 | grep ok | wc -l) 1 "node ids need not start at 1"
+is $(xg -Vrv data/z.vg 2>&1 | grep ok | wc -l) 1 "a 1mb graph verifies"
 xg -Vv data/z.vg -o data/z.vg.idx 2>/dev/null
 is $? 0 "serialization works"
 rm -f data/z.vg.idx
@@ -21,7 +22,7 @@ xg -Vv data/cyclic_all.vg -o c.idx 2>/dev/null
 is $(xg -c 10 -n 1 -i c.idx -T | grep '-' | wc -l) 2 "graphs with cycles and edges from specific sides can be stored and queried"
 rm c.idx
 
-is $(xg -Vv data/cyclic_path.vg 2>&1 | grep ok | wc -l) 1 "a graph with a path cycle validates"
+is $(xg -Vrv data/cyclic_path.vg 2>&1 | grep ok | wc -l) 1 "a graph with a path cycle validates"
 
-is $(xg -Vv data/self_loop_paths.vg 2>&1 | grep ok | wc -l) 1 "a small graph with all self loops validates"
-is $(xg -Vv data/b.vg 2>&1 | grep ok | wc -l) 1 "a large graph with doubly-reversing edges validates"
+is $(xg -Vrv data/self_loop_paths.vg 2>&1 | grep ok | wc -l) 1 "a small graph with all self loops validates"
+is $(xg -Vrv data/b.vg 2>&1 | grep ok | wc -l) 1 "a large graph with doubly-reversing edges validates"


### PR DESCRIPTION
This makes including perfect match paths from the graph as threads optional (off by default), and switches the convert-to-SDSL serialization for serialization using the new code in DYNAMIC.
