### PR TITLE
Add interface to explore graphs using lengths in addtion to id space

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1815,8 +1815,12 @@ int64_t XG::approx_path_distance(const string& name, int64_t id1, int64_t id2) c
     vector<size_t> positions1 = node_positions_in_path(next1, name);
     vector<size_t> positions2 = node_positions_in_path(prev2, name);
     // use the last node1 position and first node2 position. 
-    size_t pos1 = positions1.back();
-    size_t pos2 = positions2[0];
+    int64_t pos1 = (int64_t)positions1.back();
+    int64_t pos2 = (int64_t)positions2[0];
+    // shift over to the right of the left node if it's unchanged
+    if (next1 == id1) {
+        pos1 += node_length(next1);
+    }
 
     return abs(pos2 - pos1);
 }

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1725,7 +1725,7 @@ int64_t XG::next_path_node_by_id(size_t path_rank, int64_t id) const {
     // find number of members before our node in the path
     size_t members_rank_at_node = path->members_rank(entity_rank - 1);
     // next member doesn't exist
-    if (members_rank_at_node == path->member_count) {
+    if (members_rank_at_node == path->members.size()) {
         return 0;
     }
     // hop to the next member

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1567,9 +1567,12 @@ void XG::expand_context_by_length(Graph& g, size_t length, bool add_paths) const
                         auto it = node_table.find(other);
                         bool updated = false;
                         if (it == node_table.end()) {
+                            auto entry = make_pair(numeric_limits<int64_t>::max(),
+                                                   numeric_limits<int64_t>::max());
+                            it = node_table.insert(make_pair(other, entry)).first;
                             updated = true;
-                            node_table[other] = make_pair(other_dist, to_end);
-                        } else if (!to_end && other_dist < it->second.first) {
+                        }
+                        if (!to_end && other_dist < it->second.first) {
                             updated = true;
                             node_table[other].first = other_dist;
                         } else if (to_end && other_dist < it->second.second) {
@@ -1581,7 +1584,6 @@ void XG::expand_context_by_length(Graph& g, size_t length, bool add_paths) const
                             Node* np = g.add_node();
                             nodes[other] = np;
                             *np = node(other);
-                            cerr << "adding " << np->id() << endl;
                         }
                         // create all links back to graph, so as not to break paths
                         for (auto& other_edge : edges_of(other)) {
@@ -1595,7 +1597,6 @@ void XG::expand_context_by_length(Graph& g, size_t length, bool add_paths) const
                                 edges.find(sides) == edges.end()) {
                                 Edge* ep = g.add_edge(); *ep = other_edge;
                                 edges[sides] = ep;
-                                cerr << "adding " << other_edge.from() << "->" << other_edge.to() << ":\n";
                             }
                         }
                         // revisit the other node
@@ -1610,7 +1611,7 @@ void XG::expand_context_by_length(Graph& g, size_t length, bool add_paths) const
                     lambda(edge.to(), edge.from_start(), edge.to_end());
                 }
                 if (edge.to() == id) {
-                    lambda(edge.from(), edge.to_end(), edge.from_start());
+                    lambda(edge.from(), !edge.to_end(), !edge.from_start());
                 }
             }
         }

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1689,6 +1689,30 @@ void XG::get_id_range(int64_t id1, int64_t id2, Graph& g) const {
     }
 }
 
+// walk forward in id space, collecting nodes, until at least length bases covered
+// (or end of graph reached).  if forward is false, do go backward
+void XG::get_id_range_by_length(int64_t id, int64_t length, Graph& g, bool forward) const {
+    // find out first base of node's position in the sequence vector
+    size_t rank = id_to_rank(id);
+    size_t start = s_cbv_select(rank);
+    size_t end;
+    // jump by length, checking to make sure we stay in bounds
+    if (forward) {
+        end = s_cbv_rank(min(s_cbv.size() - 1, start + node_length(id) + length));
+    } else {
+        end = s_cbv_rank(1 + max((int64_t)0, (int64_t)(start  - length)));
+    }
+    // convert back to id
+    int64_t id2 = rank_to_id(end);
+
+    // get the id range
+    if (!forward) {
+        swap(id, id2);
+    }
+    get_id_range(id, id2, g);
+}
+
+
 /*
 void XG::get_connected_nodes(Graph& g) {
 }

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -123,6 +123,19 @@ public:
     int64_t node_at_path_position(const string& name, size_t pos) const;
     Mapping mapping_at_path_position(const string& name, size_t pos) const;
     size_t path_length(const string& name) const;
+    // if node is on path, return it.  otherwise, return next node (in id space)
+    // that is on path.  if none exists, return 0
+    int64_t next_path_node_by_id(size_t path_rank, int64_t id) const;
+    // if node is on path, return it.  otherwise, return previous node (in id space)
+    // that is on path.  if none exists, return 0
+    int64_t prev_path_node_by_id(size_t path_rank, int64_t id) const;
+    // estimate distance (in bp) between two nodes along a path.
+    // if a nodes isn't on the path, the nearest node on the path (using id space)
+    // is used as a proxy.  
+    int64_t approx_path_distance(const string& name, int64_t id1, int64_t id2) const;
+    // like above, but find minumum over list of paths.  if names is empty, do all paths
+    int64_t min_approx_path_distance(const vector<string>& names, int64_t id1, int64_t id2) const;
+
 
     // use_steps flag toggles whether dist refers to steps or length in base pairs
     void neighborhood(int64_t id, size_t dist, Graph& g, bool use_steps = true) const;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -124,13 +124,19 @@ public:
     Mapping mapping_at_path_position(const string& name, size_t pos) const;
     size_t path_length(const string& name) const;
 
-    void neighborhood(int64_t id, size_t steps, Graph& g) const;
+    // use_steps flag toggles whether dist refers to steps or length in base pairs
+    void neighborhood(int64_t id, size_t dist, Graph& g, bool use_steps = true) const;
     //void for_path_range(string& name, int64_t start, int64_t stop, function<void(Node)> lambda);
     void get_path_range(string& name, int64_t start, int64_t stop, Graph& g) const;
     // basic method to query regions of the graph
     // add_paths flag allows turning off the (potentially costly, and thread-locking) addition of paths
     // when these are not necessary
-    void expand_context(Graph& g, size_t steps, bool add_paths = true) const;
+    // use_steps flag toggles whether dist refers to steps or length in base pairs
+    void expand_context(Graph& g, size_t dist, bool add_paths = true, bool use_steps = true) const;
+    // expand by steps (original and default)
+    void expand_context_by_steps(Graph& g, size_t steps, bool add_paths = true) const;
+    // expand by length
+    void expand_context_by_length(Graph& g, size_t length, bool add_paths = true) const;
     void get_connected_nodes(Graph& g) const;
     void get_id_range(int64_t id1, int64_t id2, Graph& g) const;
 
@@ -324,6 +330,8 @@ public:
     // not duplicated here.
     
     sd_vector<> members;
+    rank_support_sd<1> members_rank;
+    select_support_sd<1> members_select;    
     wt_int<> ids;
     sd_vector<> directions; // forward or backward through nodes
     int_vector<> positions;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -152,6 +152,9 @@ public:
     void expand_context_by_length(Graph& g, size_t length, bool add_paths = true) const;
     void get_connected_nodes(Graph& g) const;
     void get_id_range(int64_t id1, int64_t id2, Graph& g) const;
+    // walk forward in id space, collecting nodes, until at least length bases covered
+    // (or end of graph reached).  if forward is false, go backwards...
+    void get_id_range_by_length(int64_t id1, int64_t length, Graph& g, bool forward) const;
 
     // gPBWT interface
     


### PR DESCRIPTION
No rush to merge until mapper changed to optionally use this...
- functions to estimate distance between two nodes by quickly projecting onto path(s) (projection done using ids)
- graph-traversal that expands a graph by length instead of steps (length of nodes in a valid path outward from starting graph)
- node id range lookup based on starting node and length (walk node id's until length is covered).

Unfortunately, this will break binary compatibility due to adding rank and select support to members vectors of xg paths. 

Would like to get this stuff behind a common interface in vg so that toggling between existing id-space logic and this distance-based logic can get centralized...
