### PR TITLE
Improve memory safety for XGPaths

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -95,6 +95,11 @@ XG::XG(function<void(function<void(Graph&)>)> get_chunks)
 }
 
 XG::~XG(void) {
+    // Clean up any created XGPaths
+    while (!paths.empty()) {
+        delete paths.back();
+        paths.pop_back();
+    }
 }
 
 void XG::load(istream& in) {

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -61,6 +61,12 @@ public:
     XG(istream& in);
     XG(Graph& graph);
     XG(function<void(function<void(Graph&)>)> get_chunks);
+    
+    // Don't let anyone copy or assign, because we own objects pointed to by
+    // pointers. TODO: use unique_ptr or actually copy owned XGPaths.
+    XG(const XG& other) = delete;
+    XG& operator=(const XG& other) = delete;
+    
     void from_stream(istream& in, bool validate_graph = false,
         bool print_graph = false, bool store_threads = false,
         bool is_sorted_dag = false);


### PR DESCRIPTION
Closes #44.

Also prevents XG objects form being copied or moved, at least until we have code to deal with the ownership of XGPath objects on the heap.

@ekg is there a reason we're using a `vector<XGPath*>` and not a `vector<XGPath>`?