### PR TITLE
Speed and correctness improvements

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2206,8 +2206,6 @@ int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_sid
     return new_visit_offset;
 }
 
-#define VERBOSE_DEBUG
-
 void XG::insert_threads_into_dag(const vector<thread_t>& t) {
 
     auto emit_destinations = [&](int64_t node_id, bool is_reverse, vector<size_t> destinations) {
@@ -2236,15 +2234,6 @@ void XG::insert_threads_into_dag(const vector<thread_t>& t) {
         // We're departing along this edge, so our orientation cares about
         // whether we have to take the edge forward or backward when departing.
         auto edge_rank = edge_rank_as_entity(canonical);
-        
-        if (edge_rank == numeric_limits<size_t>::max()) {
-            cerr << "Want " << canonical.from() << " " << canonical.from_start() << " " << canonical.to() << " " << canonical.to_end() << endl;
-            cerr << "Have: " << endl;
-            for (auto& other : edges_of(node_id)) {
-                cerr << other.from() << " " << other.from_start() << " " << other.to() << " " << other.to_end() << endl;
-            }
-        }
-        
         assert(edge_rank != numeric_limits<size_t>::max()); // We must actually have the edge
         int64_t edge_orientation_number = (edge_rank - 1) * 2 +
             depart_by_reverse(canonical, node_id, from_start);
@@ -2454,8 +2443,6 @@ void XG::insert_threads_into_dag(const vector<thread_t>& t) {
     
     
 }
-
-#undef VERBOSE_DEBUG
 
 void XG::insert_thread(const thread_t& t) {
     // We're going to insert this thread
@@ -2670,8 +2657,6 @@ auto XG::extract_threads() const -> list<thread_t> {
             continue;
         }
 
-#define debug
-#define VERBOSE_DEBUG    
         for(int64_t j = 0; j < ts_iv[i]; j++) {
             // For every thread starting there
       
@@ -2752,8 +2737,6 @@ auto XG::extract_threads() const -> list<thread_t> {
             
         }
     }
-#undef debug
-#undef VERBOSE_DEBUG
     
     return found;
 }

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1313,8 +1313,8 @@ size_t XG::edge_rank_as_entity(int64_t id1, bool from_start, int64_t id2, bool t
             return i+1;
         }
     }
-    cerr << "[xg] error: edge does not exist: " << id1 << " " << from_start << " -> " << id2 << " " << to_end << endl;
-    assert(false);
+    // Otherwise the edge doesn't exist.
+    return numeric_limits<size_t>.max();
 }
 
 size_t XG::edge_rank_as_entity(const Edge& edge) const {
@@ -1334,8 +1334,8 @@ size_t XG::edge_rank_as_entity(const Edge& edge) const {
         assert(!entity_is_node(rank));
         return rank;
     } else {
-        // Someone gave us an edge that doesn't exist.
-        assert(false);
+        // Otherwise the edge doesn't exist.
+        return numeric_limits<size_t>.max();
     }
 }
 

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -1313,7 +1313,7 @@ size_t XG::edge_rank_as_entity(int64_t id1, bool from_start, int64_t id2, bool t
             return i+1;
         }
     }
-    //cerr << "edge does not exist: " << id1 << " -> " << id2 << endl;
+    cerr << "[xg] error: edge does not exist: " << id1 << " " << from_start << " -> " << id2 << " " << to_end << endl;
     assert(false);
 }
 

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -182,7 +182,7 @@ void XGPath::load(istream& in) {
 
 size_t XGPath::serialize(std::ostream& out,
                          sdsl::structure_tree_node* v,
-                         std::string name) {
+                         std::string name) const {
     sdsl::structure_tree_node* child = sdsl::structure_tree::add_child(v, name, sdsl::util::class_name(*this));
     size_t written = 0;
     written += members.serialize(out, child, "path_membership_" + name);
@@ -317,7 +317,7 @@ XGPath::XGPath(const string& path_name,
     util::assign(offsets_select, bit_vector::select_1_type(&offsets));
 }
 
-Mapping XGPath::mapping(size_t offset) {
+Mapping XGPath::mapping(size_t offset) const {
     // TODO actually store the "real" mapping
     Mapping m;
     // store the starting position and series of edits
@@ -1345,7 +1345,7 @@ Path XG::path(const string& name) const {
     // Extract a whole path by name
     
     // First find the XGPath we're using to store it.
-    XGPath& xgpath = *(paths[path_rank(name)-1]);
+    const XGPath& xgpath = *(paths[path_rank(name)-1]);
     
     // Make a new path to fill in
     Path to_return;
@@ -1797,7 +1797,7 @@ size_t XG::path_length(size_t rank) const {
 int64_t XG::next_path_node_by_id(size_t path_rank, int64_t id) const {
 
     // find our node in the members bit vector of the xgpath
-    XGPath* path = paths[path_rank - 1];
+    const XGPath* path = paths[path_rank - 1];
     size_t node_rank = id_to_rank(id);
     size_t entity_rank = node_rank_as_entity(node_rank);
     // if it's a path member, we're done
@@ -2386,8 +2386,8 @@ void XG::insert_threads_into_dag(const vector<thread_t>& t) {
                     // Figure out the rank of the edge we need to take to get
                     // there. Note that we need to make sure we can handle going
                     // forward and backward over edges.
-                    size_t next_edge_rank = edge_rank_as_entity(make_edge(node_id, node_is_reverse,
-                        next_node_id, next_is_reverse));
+                    Edge canonical = canonicalize(make_edge(node_id, node_is_reverse, next_node_id, next_is_reverse));
+                    size_t next_edge_rank = edge_rank_as_entity(canonical);
                     
                     // Look up what local edge number that edge gets and say we follow it.
                     destinations.push_back(edge_rank_to_local_edge_number.at(next_edge_rank));

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -116,14 +116,17 @@ public:
     vector<Edge> edges_on_start(int64_t id) const;
     vector<Edge> edges_on_end(int64_t id) const;
     size_t node_rank_as_entity(int64_t id) const;
+    /// Get the rank of the edge, or numeric_limits<size_t>.max() if no such edge exists.
+    /// Edge must be specified in canonical orientation.
     size_t edge_rank_as_entity(int64_t id1, bool from_start, int64_t id2, bool to_end) const;
-    // Supports the edge articulated in any orientation. Edge must exist.
+    /// Supports the edge articulated in any orientation.
     size_t edge_rank_as_entity(const Edge& edge) const;
     // Given an edge which is in the graph in some orientation, return the edge
     // oriented as it actually appears.
     Edge canonicalize(const Edge& edge);
     bool entity_is_node(size_t rank) const;
     size_t entity_rank_as_node_rank(size_t rank) const;
+    /// Returns true if the given edge is present in the given orientation, and false otherwise.
     bool has_edge(int64_t id1, bool is_start, int64_t id2, bool is_end) const;
 
     // Pull out the path with the given name.

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -445,6 +445,13 @@ public:
     // Path names are stored in the XG object, in a compressed fashion, and are
     // not duplicated here.
     
+    // These contain rank and select supports and so cannot move or be copied
+    // without code to update them.
+    XGPath(const XGPath& other) = delete;
+    XGPath(XGPath&& other) = delete;
+    XGPath& operator=(const XGPath& other) = delete;
+    XGPath& operator=(XGPath&& other) = delete;
+    
     sd_vector<> members;
     rank_support_sd<1> members_rank;
     select_support_sd<1> members_select;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -123,7 +123,7 @@ public:
     size_t edge_rank_as_entity(const Edge& edge) const;
     // Given an edge which is in the graph in some orientation, return the edge
     // oriented as it actually appears.
-    Edge canonicalize(const Edge& edge);
+    Edge canonicalize(const Edge& edge) const;
     bool entity_is_node(size_t rank) const;
     size_t entity_rank_as_node_rank(size_t rank) const;
     /// Returns true if the given edge is present in the given orientation, and false otherwise.

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -128,6 +128,8 @@ public:
     size_t entity_rank_as_node_rank(size_t rank) const;
     /// Returns true if the given edge is present in the given orientation, and false otherwise.
     bool has_edge(int64_t id1, bool is_start, int64_t id2, bool is_end) const;
+    /// Returns true if the given edge is present in either orientation, and false otherwise.
+    bool has_edge(const Edge& edge) const;
 
     // Pull out the path with the given name.
     Path path(const string& name) const;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -62,10 +62,12 @@ public:
     XG(Graph& graph);
     XG(function<void(function<void(Graph&)>)> get_chunks);
     
-    // Don't let anyone copy or assign, because we own objects pointed to by
-    // pointers. TODO: use unique_ptr or actually copy owned XGPaths.
+    // We cannot move, assign, or copy until we add code to point SDSL suppots
+    // at the new addresses for their vectors.
     XG(const XG& other) = delete;
+    XG(XG&& other) = delete;
     XG& operator=(const XG& other) = delete;
+    XG& operator=(XG&& other) = delete;
     
     void from_stream(istream& in, bool validate_graph = false,
         bool print_graph = false, bool store_threads = false,

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -458,9 +458,9 @@ public:
     void load(istream& in);
     size_t serialize(std::ostream& out,
                      sdsl::structure_tree_node* v = NULL,
-                     std::string name = "");
+                     std::string name = "") const;
     // Get a mapping. Note that the mapping will not have its lengths filled in.
-    Mapping mapping(size_t offset); // 0-based
+    Mapping mapping(size_t offset) const; // 0-based
 };
 
 


### PR DESCRIPTION
This set of changes canonicalizes edges based on edge contents: doubly-reversing edges, and singly-reversing edges from larger to smaller values, will be replaced with their reversed counterparts in the index.

This and a couple other changes eliminate a lot of has_edge calls, which are relatively slow.

I'm also locking down XG objects so they can't be copied or moved, until we add code to point the new SDSL support copies at their copied/moved vectors.