### PR TITLE
Add xg functionality needed for haplotype decompositions

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -3308,3 +3308,47 @@ int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_sid
     // threads going there that come via this edge.
     return new_visit_offset;
 }
+
+thread_t extract_thread(xg::XG::ThreadMapping node, int64_t offset = 0, int64_t max_length = 0) {
+  thread_t path;
+  int64_t side = (node.node_id)*2 + node.is_reverse;
+  bool continue_search = true;
+  while(continue_search) {
+    xg::XG::ThreadMapping m = {rank_to_id(side / 2), (bool) (side % 2)};
+    path.push_back(m);
+    // Work out where we go:
+    // What edge of the available edges do we take?
+    int64_t edge_index = bs_get(side, offset);
+    assert(edge_index != BS_SEPARATOR);
+    if(edge_index == BS_NULL) {
+        // Path ends here.
+        break;
+    } else {
+        // If we've got an edge, convert to an actual edge index
+        edge_index -= 2;
+    }
+    // We also should not have negative edges.
+    assert(edge_index >= 0);
+    // Look at the edges we could have taken next
+    vector<Edge> edges_out = side % 2 ? edges_on_start(rank_to_id(side / 2)) :
+          edges_on_end(rank_to_id(side / 2));
+    assert(edge_index < edges_out.size());
+    Edge& taken = edges_out[edge_index];
+    // Follow the edge
+    int64_t other_node = taken.from() == rank_to_id(side / 2) ? taken.to() :
+          taken.from();
+    bool other_orientation = (side % 2) != taken.from_start() != taken.to_end();
+    // Get the side
+    int64_t other_side = id_to_rank(other_node) * 2 + other_orientation;
+    // Go there with where_to
+    offset = where_to(side, offset, other_side);
+    side = other_side;
+    // Continue the process from this new side
+    if(max_length != 0) {
+      if(path.size() >= max_length) {
+        continue_search = false;
+      }
+    }
+  }
+  return path;
+}

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2119,98 +2119,28 @@ int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_sid
     // Given that we were at visit_offset on the current side, where will we be
     // on the new side? 
     
-    // What will the new visit offset be?
-    int64_t new_visit_offset = 0;
-    
     // Work out where we're going as a node and orientation
     int64_t new_node_id = rank_to_id(new_side / 2);
     bool new_node_is_reverse = new_side % 2;
-    
-    // Work out what edges are going into the place we're going into.
-    vector<Edge> edges = new_node_is_reverse ? edges_on_end(new_node_id) : edges_on_start(new_node_id);
     
     // Work out what node and orientation we came from
     int64_t old_node_id = rank_to_id(current_side / 2);
     bool old_node_is_reverse = current_side % 2;
     
-    // What edge are we following
-    Edge edge_taken = make_edge(old_node_id, old_node_is_reverse, new_node_id, new_node_is_reverse);
-    
-    // Make sure we find it
-    bool edge_found = false;
-    
-    for(auto& edge : edges) {
-        // Look at every edge in order.
-        
-        if(edges_equivalent(edge, edge_taken)) {
-            // If we found the edge we're taking, break.
-            edge_found = true;
-            break;
-        }
-        
-        // Otherwise add in the threads on this edge to the offset
-
-        // Get the orientation number for this edge (which is *not* the edge we
-        // are following and so doesn't involve old_node_anything). We only
-        // treat it as reverse if the reverse direction is the only direction we
-        // can take to get here.
-        int64_t edge_orientation_number = ((edge_rank_as_entity(edge) - 1) * 2) + arrive_by_reverse(edge, new_node_id, new_node_is_reverse);
-        
-        int64_t contribution = h_iv[edge_orientation_number];
-#ifdef VERBOSE_DEBUG
-        cerr << contribution << " (from prev edge " << edge.from() << (edge.from_start() ? "L" : "R") << "-" << edge.to() << (edge.to_end() ? "R" : "L") << " at " << edge_orientation_number << ") + ";
-#endif
-        new_visit_offset += contribution;
-    }
-    
-    assert(edge_found);
-    
-    // What edge out of all the edges we can take are we taking?
-    int64_t edge_taken_index = -1;
+    // Work out what edges are going into the place we're going into.
+    vector<Edge> edges = new_node_is_reverse ? edges_on_end(new_node_id) : edges_on_start(new_node_id);
     
     // Look at the edges we could have taken next
     vector<Edge> edges_out = old_node_is_reverse ? edges_on_start(old_node_id) : edges_on_end(old_node_id);
     
-    for(int64_t i = 0; i < edges_out.size(); i++) {
-        if(edges_equivalent(edges_out[i], edge_taken)) {
-            // i is the index of the edge we took, of the edges available to us.
-            edge_taken_index = i;
-            break;
-        }
-    }
-    
-    assert(edge_taken_index != -1);
-    
-    // Get the rank in B_s[] for our current side of our visit offset among
-    // B_s[] entries pointing to the new node and add that in. Make sure to +2
-    // to account for the nulls and separators.
-    int64_t contribution = bs_rank(current_side, visit_offset, edge_taken_index + 2);
-#ifdef VERBOSE_DEBUG
-    cerr << contribution << " (via this edge) + ";
-#endif
-    new_visit_offset += contribution;
-    
-    // Get the number of threads starting at the new side and add that in.
-    contribution = ts_iv[new_side];
-#ifdef VERBOSE_DEBUG
-    cerr << contribution << " (starting here) = ";
-#endif
-    new_visit_offset += contribution;
-#ifdef VERBOSE_DEBUG
-    cerr << new_visit_offset << endl;
-#endif
-    
-    // Now we know where it actually ends up: after all the threads that start,
-    // all the threads that come in via earlier edges, and all the previous
-    // threads going there that come via this edge.
-    return new_visit_offset;
+    return where_to(current_side, visit_offset, new_side, edges, edges_out);
 }
 
 int64_t XG::node_height(XG::ThreadMapping node) const {
   return h_iv[(node_rank_as_entity(node.node_id) - 1) * 2 + node.is_reverse];
 }
 
-int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_side, vector<Edge>& edges, vector<Edge>& edges_out) const {
+int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_side, vector<Edge>& edges_into_new, vector<Edge>& edges_out_of_old) const {
     // Given that we were at visit_offset on the current side, where will we be
     // on the new side?
 
@@ -2233,7 +2163,7 @@ int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_sid
     // Make sure we find it
     bool edge_found = false;
 
-    for(auto& edge : edges) {
+    for(auto& edge : edges_into_new) {
         // Look at every edge in order.
 
         if(edges_equivalent(edge, edge_taken)) {
@@ -2264,8 +2194,8 @@ int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_sid
 
     // Look at the edges we could have taken next
 
-    for(int64_t i = 0; i < edges_out.size(); i++) {
-        if(edges_equivalent(edges_out[i], edge_taken)) {
+    for(int64_t i = 0; i < edges_out_of_old.size(); i++) {
+        if(edges_equivalent(edges_out_of_old[i], edge_taken)) {
             // i is the index of the edge we took, of the edges available to us.
             edge_taken_index = i;
             break;
@@ -2299,9 +2229,7 @@ int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_sid
     return new_visit_offset;
 }
 
-using thread_t = vector<XG::ThreadMapping>;
-
-thread_t XG::extract_thread(xg::XG::ThreadMapping node, int64_t offset = 0, int64_t max_length = 0) {
+XG::thread_t XG::extract_thread(xg::XG::ThreadMapping node, int64_t offset = 0, int64_t max_length = 0) {
   thread_t path;
   int64_t side = (node.node_id)*2 + node.is_reverse;
   bool continue_search = true;
@@ -3199,48 +3127,6 @@ void XG::extend_search(ThreadSearchState& state, const thread_t& t) const {
         state.current_side = next_side;
     }
 }
-
-void XG::extend_search(ThreadSearchState& state, const ThreadMapping& t) const {
-    // Just make it into a temporary vector
-    extend_search(state, thread_t{t});
-}
-
-XG::ThreadSearchState XG::select_starting(const ThreadMapping& start) const {
-    // We need to select just the threads starting at this node with this
-    // mapping, rather than those coming in from elsewhere.
-    
-    // Make a search state with nothing searched
-    ThreadSearchState state;
-    
-    // Say we've searched this ThreadMapping's side.    
-    state.current_side = id_to_rank(start.node_id) * 2 + start.is_reverse;
-    
-    // Threads starting at a node come first, so select from 0 to the number of
-    // threads that start there.
-    state.range_start = 0;
-    state.range_end = ts_iv[state.current_side];
-    
-    return state;
-}
-
-XG::ThreadSearchState XG::select_continuing(const ThreadMapping& start) const {
-    // We need to select just the threads coming in from elsewhere, and not
-    // those starting here.
-    
-    // Make a search state with nothing searched
-    ThreadSearchState state;
-    
-    // Say we've searched this ThreadMapping's side.    
-    state.current_side = id_to_rank(start.node_id) * 2 + start.is_reverse;
-    
-    // Threads starting at a node come first, so select from past them to the
-    // number of threads total on the node.
-    state.range_start = ts_iv[state.current_side];
-    state.range_end = h_iv[state.current_side];
-    
-    return state;
-}
-
 
 size_t serialize(XG::rank_select_int_vector& to_serialize, ostream& out,
     sdsl::structure_tree_node* parent, const std::string name) {

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2206,6 +2206,143 @@ int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_sid
     return new_visit_offset;
 }
 
+int64_t XG::node_height(XG::ThreadMapping node) const {
+  return h_iv[(node_rank_as_entity(node.node_id) - 1) * 2 + node.is_reverse];
+}
+
+int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_side, vector<Edge>& edges, vector<Edge>& edges_out) const {
+    // Given that we were at visit_offset on the current side, where will we be
+    // on the new side?
+
+    // What will the new visit offset be?
+    int64_t new_visit_offset = 0;
+
+    // Work out where we're going as a node and orientation
+    int64_t new_node_id = rank_to_id(new_side / 2);
+    bool new_node_is_reverse = new_side % 2;
+
+    // Work out what edges are going into the place we're going into.
+
+    // Work out what node and orientation we came from
+    int64_t old_node_id = rank_to_id(current_side / 2);
+    bool old_node_is_reverse = current_side % 2;
+
+    // What edge are we following
+    Edge edge_taken = make_edge(old_node_id, old_node_is_reverse, new_node_id, new_node_is_reverse);
+
+    // Make sure we find it
+    bool edge_found = false;
+
+    for(auto& edge : edges) {
+        // Look at every edge in order.
+
+        if(edges_equivalent(edge, edge_taken)) {
+            // If we found the edge we're taking, break.
+            edge_found = true;
+            break;
+        }
+
+        // Otherwise add in the threads on this edge to the offset
+
+        // Get the orientation number for this edge (which is *not* the edge we
+        // are following and so doesn't involve old_node_anything). We only
+        // treat it as reverse if the reverse direction is the only direction we
+        // can take to get here.
+        int64_t edge_orientation_number = ((edge_rank_as_entity(edge) - 1) * 2) + arrive_by_reverse(edge, new_node_id, new_node_is_reverse);
+
+        int64_t contribution = h_iv[edge_orientation_number];
+#ifdef VERBOSE_DEBUG
+        cerr << contribution << " (from prev edge " << edge.from() << (edge.from_start() ? "L" : "R") << "-" << edge.to() << (edge.to_end() ? "R" : "L") << " at " << edge_orientation_number << ") + ";
+#endif
+        new_visit_offset += contribution;
+    }
+
+    assert(edge_found);
+
+    // What edge out of all the edges we can take are we taking?
+    int64_t edge_taken_index = -1;
+
+    // Look at the edges we could have taken next
+
+    for(int64_t i = 0; i < edges_out.size(); i++) {
+        if(edges_equivalent(edges_out[i], edge_taken)) {
+            // i is the index of the edge we took, of the edges available to us.
+            edge_taken_index = i;
+            break;
+        }
+    }
+
+    assert(edge_taken_index != -1);
+
+    // Get the rank in B_s[] for our current side of our visit offset among
+    // B_s[] entries pointing to the new node and add that in. Make sure to +2
+    // to account for the nulls and separators.
+    int64_t contribution = bs_rank(current_side, visit_offset, edge_taken_index + 2);
+#ifdef VERBOSE_DEBUG
+    cerr << contribution << " (via this edge) + ";
+#endif
+    new_visit_offset += contribution;
+
+    // Get the number of threads starting at the new side and add that in.
+    contribution = ts_iv[new_side];
+#ifdef VERBOSE_DEBUG
+    cerr << contribution << " (starting here) = ";
+#endif
+    new_visit_offset += contribution;
+#ifdef VERBOSE_DEBUG
+    cerr << new_visit_offset << endl;
+#endif
+
+    // Now we know where it actually ends up: after all the threads that start,
+    // all the threads that come in via earlier edges, and all the previous
+    // threads going there that come via this edge.
+    return new_visit_offset;
+}
+
+thread_t extract_thread(xg::XG::ThreadMapping node, int64_t offset = 0, int64_t max_length = 0) {
+  thread_t path;
+  int64_t side = (node.node_id)*2 + node.is_reverse;
+  bool continue_search = true;
+  while(continue_search) {
+    xg::XG::ThreadMapping m = {rank_to_id(side / 2), (bool) (side % 2)};
+    path.push_back(m);
+    // Work out where we go:
+    // What edge of the available edges do we take?
+    int64_t edge_index = bs_get(side, offset);
+    assert(edge_index != BS_SEPARATOR);
+    if(edge_index == BS_NULL) {
+        // Path ends here.
+        break;
+    } else {
+        // If we've got an edge, convert to an actual edge index
+        edge_index -= 2;
+    }
+    // We also should not have negative edges.
+    assert(edge_index >= 0);
+    // Look at the edges we could have taken next
+    vector<Edge> edges_out = side % 2 ? edges_on_start(rank_to_id(side / 2)) :
+          edges_on_end(rank_to_id(side / 2));
+    assert(edge_index < edges_out.size());
+    Edge& taken = edges_out[edge_index];
+    // Follow the edge
+    int64_t other_node = taken.from() == rank_to_id(side / 2) ? taken.to() :
+          taken.from();
+    bool other_orientation = (side % 2) != taken.from_start() != taken.to_end();
+    // Get the side
+    int64_t other_side = id_to_rank(other_node) * 2 + other_orientation;
+    // Go there with where_to
+    offset = where_to(side, offset, other_side);
+    side = other_side;
+    // Continue the process from this new side
+    if(max_length != 0) {
+      if(path.size() >= max_length) {
+        continue_search = false;
+      }
+    }
+  }
+  return path;
+}
+
 void XG::insert_threads_into_dag(const vector<thread_t>& t) {
 
     auto emit_destinations = [&](int64_t node_id, bool is_reverse, vector<size_t> destinations) {
@@ -3214,141 +3351,4 @@ void extract_pos_substr(const string& pos_str, int64_t& id, bool& is_rev, size_t
     }
 }
 
-}
-
-int64_t XG::node_height(XG::ThreadMapping node) const {
-  return h_iv[(node_rank_as_entity(node.node_id) - 1) * 2 + node.is_reverse];
-}
-
-int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_side, vector<Edge>& edges, vector<Edge>& edges_out) const {
-    // Given that we were at visit_offset on the current side, where will we be
-    // on the new side?
-
-    // What will the new visit offset be?
-    int64_t new_visit_offset = 0;
-
-    // Work out where we're going as a node and orientation
-    int64_t new_node_id = rank_to_id(new_side / 2);
-    bool new_node_is_reverse = new_side % 2;
-
-    // Work out what edges are going into the place we're going into.
-
-    // Work out what node and orientation we came from
-    int64_t old_node_id = rank_to_id(current_side / 2);
-    bool old_node_is_reverse = current_side % 2;
-
-    // What edge are we following
-    Edge edge_taken = make_edge(old_node_id, old_node_is_reverse, new_node_id, new_node_is_reverse);
-
-    // Make sure we find it
-    bool edge_found = false;
-
-    for(auto& edge : edges) {
-        // Look at every edge in order.
-
-        if(edges_equivalent(edge, edge_taken)) {
-            // If we found the edge we're taking, break.
-            edge_found = true;
-            break;
-        }
-
-        // Otherwise add in the threads on this edge to the offset
-
-        // Get the orientation number for this edge (which is *not* the edge we
-        // are following and so doesn't involve old_node_anything). We only
-        // treat it as reverse if the reverse direction is the only direction we
-        // can take to get here.
-        int64_t edge_orientation_number = ((edge_rank_as_entity(edge) - 1) * 2) + arrive_by_reverse(edge, new_node_id, new_node_is_reverse);
-
-        int64_t contribution = h_iv[edge_orientation_number];
-#ifdef VERBOSE_DEBUG
-        cerr << contribution << " (from prev edge " << edge.from() << (edge.from_start() ? "L" : "R") << "-" << edge.to() << (edge.to_end() ? "R" : "L") << " at " << edge_orientation_number << ") + ";
-#endif
-        new_visit_offset += contribution;
-    }
-
-    assert(edge_found);
-
-    // What edge out of all the edges we can take are we taking?
-    int64_t edge_taken_index = -1;
-
-    // Look at the edges we could have taken next
-
-    for(int64_t i = 0; i < edges_out.size(); i++) {
-        if(edges_equivalent(edges_out[i], edge_taken)) {
-            // i is the index of the edge we took, of the edges available to us.
-            edge_taken_index = i;
-            break;
-        }
-    }
-
-    assert(edge_taken_index != -1);
-
-    // Get the rank in B_s[] for our current side of our visit offset among
-    // B_s[] entries pointing to the new node and add that in. Make sure to +2
-    // to account for the nulls and separators.
-    int64_t contribution = bs_rank(current_side, visit_offset, edge_taken_index + 2);
-#ifdef VERBOSE_DEBUG
-    cerr << contribution << " (via this edge) + ";
-#endif
-    new_visit_offset += contribution;
-
-    // Get the number of threads starting at the new side and add that in.
-    contribution = ts_iv[new_side];
-#ifdef VERBOSE_DEBUG
-    cerr << contribution << " (starting here) = ";
-#endif
-    new_visit_offset += contribution;
-#ifdef VERBOSE_DEBUG
-    cerr << new_visit_offset << endl;
-#endif
-
-    // Now we know where it actually ends up: after all the threads that start,
-    // all the threads that come in via earlier edges, and all the previous
-    // threads going there that come via this edge.
-    return new_visit_offset;
-}
-
-thread_t extract_thread(xg::XG::ThreadMapping node, int64_t offset = 0, int64_t max_length = 0) {
-  thread_t path;
-  int64_t side = (node.node_id)*2 + node.is_reverse;
-  bool continue_search = true;
-  while(continue_search) {
-    xg::XG::ThreadMapping m = {rank_to_id(side / 2), (bool) (side % 2)};
-    path.push_back(m);
-    // Work out where we go:
-    // What edge of the available edges do we take?
-    int64_t edge_index = bs_get(side, offset);
-    assert(edge_index != BS_SEPARATOR);
-    if(edge_index == BS_NULL) {
-        // Path ends here.
-        break;
-    } else {
-        // If we've got an edge, convert to an actual edge index
-        edge_index -= 2;
-    }
-    // We also should not have negative edges.
-    assert(edge_index >= 0);
-    // Look at the edges we could have taken next
-    vector<Edge> edges_out = side % 2 ? edges_on_start(rank_to_id(side / 2)) :
-          edges_on_end(rank_to_id(side / 2));
-    assert(edge_index < edges_out.size());
-    Edge& taken = edges_out[edge_index];
-    // Follow the edge
-    int64_t other_node = taken.from() == rank_to_id(side / 2) ? taken.to() :
-          taken.from();
-    bool other_orientation = (side % 2) != taken.from_start() != taken.to_end();
-    // Get the side
-    int64_t other_side = id_to_rank(other_node) * 2 + other_orientation;
-    // Go there with where_to
-    offset = where_to(side, offset, other_side);
-    side = other_side;
-    // Continue the process from this new side
-    if(max_length != 0) {
-      if(path.size() >= max_length) {
-        continue_search = false;
-      }
-    }
-  }
-  return path;
 }

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2299,6 +2299,8 @@ int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_sid
     return new_visit_offset;
 }
 
+using thread_t = vector<ThreadMapping>;
+
 thread_t extract_thread(xg::XG::ThreadMapping node, int64_t offset = 0, int64_t max_length = 0) {
   thread_t path;
   int64_t side = (node.node_id)*2 + node.is_reverse;

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -2299,9 +2299,9 @@ int64_t XG::where_to(int64_t current_side, int64_t visit_offset, int64_t new_sid
     return new_visit_offset;
 }
 
-using thread_t = vector<ThreadMapping>;
+using thread_t = vector<XG::ThreadMapping>;
 
-thread_t extract_thread(xg::XG::ThreadMapping node, int64_t offset = 0, int64_t max_length = 0) {
+thread_t XG::extract_thread(xg::XG::ThreadMapping node, int64_t offset = 0, int64_t max_length = 0) {
   thread_t path;
   int64_t side = (node.node_id)*2 + node.is_reverse;
   bool continue_search = true;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -104,8 +104,16 @@ public:
     // you, from a given visit at a given side, what visit offset if you go to
     // another side.
     int64_t where_to(int64_t current_side, int64_t visit_offset, int64_t new_side) const;
+    
+    // This is another version of the where_to function which requires that you
+    // supply two vectors of edges.
+    // edges_into_new -> edges going into new_side
+    // edges_out_of_old -> edges coming out of current_side
+    // this is to save the overhead of re-extracting these edge-vectors in cases
+    // where you're calling where_to between the same two sides (but with 
+    // different offsets) many times. Otherwise use version above
     int64_t where_to(int64_t current_side, int64_t visit_offset, int64_t new_side,
-      vector<Edge>& edges, vector<Edge>& edges_out) const;
+      vector<Edge>& edges_into_new, vector<Edge>& edges_out_of_old) const;
 
     size_t id_to_rank(int64_t id) const;
     int64_t rank_to_id(size_t rank) const;
@@ -213,54 +221,45 @@ public:
     // gPBWT interface
     
 #if GPBWT_MODE == MODE_SDSL
-    /// We keep our strings in instances of this cool run-length-compressed wavelet tree.
+    // We keep our strings in instances of this cool run-length-compressed wavelet tree.
     using rank_select_int_vector = sdsl::wt_rlmn<sdsl::sd_vector<>>;
 #elif GPBWT_MODE == MODE_DYNAMIC
     using rank_select_int_vector = dyn::rle_str;
 #endif
     
     
-    /// We define a thread visit that's much smaller than a Protobuf Mapping.
+    // We define a thread visit that's much smaller than a Protobuf Mapping.
     struct ThreadMapping {
         int64_t node_id;
         bool is_reverse;
-        
-        /// We need comparison for deduplication in sets and canonically orienting threads
-        bool operator<(const ThreadMapping& other) const {
-            return tie(node_id, is_reverse) < tie(other.node_id, other.is_reverse);
-        }
     };
     
+    // we have a public function for querying the contents of the h_iv vector
     int64_t node_height(ThreadMapping node) const;
     
-    /// We define a thread as just a vector of these things, instead of a bulky
-    /// Path.
-
+    // We define a thread as just a vector of these things, instead of a bulky
+    // Path.
     using thread_t = vector<ThreadMapping>;
     
-    /// Insert a thread. Path name must be unique or empty.
+    // Insert a thread. Path name must be unique or empty.
     void insert_thread(const thread_t& t);
-    /// Insert a whole group of threads. Names should be unique or empty (though
-    /// they aren't used yet). The indexed graph must be a DAG, at least in the
-    /// subset traversed by the threads. (Reversing edges are fine, but the
-    /// threads in a node must all run in the same direction.) This uses a
-    /// special efficient batch insert algorithm for DAGs that lets us just scan
-    /// the graph and generate nodes' B_s arrays independently. This must be
-    /// called only once, and no threads can have been inserted previously.
-    /// Otherwise the gPBWT data structures will be left in an inconsistent
-    /// state.
+    // Insert a whole group of threads. Names should be unique or empty (though
+    // they aren't used yet). The indexed graph must be a DAG, at least in the
+    // subset traversed by the threads. (Reversing edges are fine, but the
+    // threads in a node must all run in the same direction.) This uses a
+    // special efficient batch insert algorithm for DAGs that lets us just scan
+    // the graph and generate nodes' B_s arrays independently. This must be
+    // called only once, and no threads can have been inserted previously.
+    // Otherwise the gPBWT data structures will be left in an inconsistent
+    // state.
     void insert_threads_into_dag(const vector<thread_t>& t);
-    /// Read all the threads embedded in the graph.
+    // Read all the threads embedded in the graph.
     list<thread_t> extract_threads() const;
-    /// Extract a particular thread by name. Name may not be empty.
-    /// TODO: Actually implement name storage for threads, so we can easily find a thread in the graph by name.
-    thread_t extract_thread(const string& name) const;
-
+    // Extract a particular thread, referring to it by its offset at node; step
+    // it out to a maximum of max_length
     thread_t extract_thread(xg::XG::ThreadMapping node, int64_t offset, int64_t max_length);
-
-    /// Count matches to a subthread among embedded threads
+    // Count matches to a subthread among embedded threads
     size_t count_matches(const thread_t& t) const;
-    /// Count matches to a subthread among embedded threads
     size_t count_matches(const Path& t) const;
     
     /**
@@ -271,38 +270,28 @@ public:
      * that can be extended to the whole collection of visits to a side.
      */
     struct ThreadSearchState {
-        /// What side have we just arrived at in the search?
+        // What side have we just arrived at in the search?
         int64_t current_side = 0;
-        /// What is the first visit at that side that is selected?
+        // What is the first visit at that side that is selected?
         int64_t range_start = 0;
-        /// And what is the past-the-last visit that is selected?
+        // And what is the past-the-last visit that is selected?
         int64_t range_end = numeric_limits<int64_t>::max();
         
-        /// How many visits are selected?
+        // How many visits are selected?
         inline int64_t count() {
             return range_end - range_start;
         }
         
-        /// Return true if the range has nothing selected.
+        // Return true if the range has nothing selected.
         inline bool is_empty() {
             return range_end <= range_start;
         }
     };
     
-    /// Extend a search with the given section of a thread.
+    // Extend a search with the given section of a thread.
     void extend_search(ThreadSearchState& state, const thread_t& t) const;
-    /// Extend a search with the given single ThreadMapping.
-    void extend_search(ThreadSearchState& state, const ThreadMapping& t) const;
-    
-    /// Select only the threads (if any) starting with a particular
-    /// ThreadMapping, and not those continuing through it.
-    ThreadSearchState select_starting(const ThreadMapping& start) const;
-    
-    /// Select only the threads (if any) continuing through a particular
-    /// ThreadMapping, and not those starting there.
-    ThreadSearchState select_continuing(const ThreadMapping& start) const;
 
-    /// Dump the whole B_s array to the given output stream as a report.
+    // Dump the whole B_s array to the given output stream as a report.
     void bs_dump(ostream& out) const;
     
     char start_marker;
@@ -450,7 +439,7 @@ private:
     void bs_insert(int64_t side, int64_t offset, destination_t value);
     
     // Prepare the B_s array data structures for query. After you call this, you
-    // shouldn't call bs_set or bs_insert.
+    // shouldn't call bset or bs_insert.
     void bs_bake();
 };
 

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -99,6 +99,13 @@ public:
     size_t node_count;
     size_t edge_count;
     size_t path_count;
+    
+    // We need the w function, which we call the "where_to" function. It tells
+    // you, from a given visit at a given side, what visit offset if you go to
+    // another side.
+    int64_t where_to(int64_t current_side, int64_t visit_offset, int64_t new_side) const;
+    int64_t where_to(int64_t current_side, int64_t visit_offset, int64_t new_side,
+      vector<Edge>& edges, vector<Edge>& edges_out) const;
 
     size_t id_to_rank(int64_t id) const;
     int64_t rank_to_id(size_t rank) const;
@@ -218,6 +225,8 @@ public:
         int64_t node_id;
         bool is_reverse;
     };
+    
+    int64_t node_height(ThreadMapping node) const;
     
     // We define a thread as just a vector of these things, instead of a bulky
     // Path.
@@ -421,13 +430,8 @@ private:
     void bs_insert(int64_t side, int64_t offset, destination_t value);
     
     // Prepare the B_s array data structures for query. After you call this, you
-    // shouldn't call bs_set or bs_insert.
+    // shouldn't call bset or bs_insert.
     void bs_bake();
-    
-    // We need the w function, which we call the "where_to" function. It tells
-    // you, from a given visit at a given side, what visit offset if you go to
-    // another side.
-    int64_t where_to(int64_t current_side, int64_t visit_offset, int64_t new_side) const;
 };
 
 class XGPath {

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -249,6 +249,7 @@ public:
     // Extract a particular thread by name. Name may not be empty.
     // TODO: Actually implement name storage for threads, so we can easily find a thread in the graph by name.
     thread_t extract_thread(const string& name) const;
+    thread_t extract_thread(xg::XG::ThreadMapping node, int64_t offset, int64_t max_length);
     // Count matches to a subthread among embedded threads
     size_t count_matches(const thread_t& t) const;
     size_t count_matches(const Path& t) const;


### PR DESCRIPTION
-Made where_to public so that haplotype exploring functions can call it
-Made a where_to which gets passed cached vectors of edges if we're calling where_to many times over a single edge
-Made a public node_height function
-Made a single thread extraction function (this is also the function where current xg is sometimes failing an assertion)