### PR TITLE
Fix bugs preventing tests from passing

### DIFF
--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -788,6 +788,7 @@ void XG::build(map<id_t, string>& node_label,
         // If we're a sorted DAG we'll batch up the paths and use a batch
         // insert.
         vector<thread_t> batch;
+        vector<string> batch_names;
     
         // Just store all the paths that are all perfect mappings as threads.
         // We end up converting *back* into thread_t objects.
@@ -806,11 +807,12 @@ void XG::build(map<id_t, string>& node_label,
             if(is_sorted_dag) {
                 // Save for a batch insert
                 batch.push_back(reconstructed);
+                batch_names.push_back(pathpair.first);
             }
             // TODO: else case!
 #elif GPBWT_MODE == MODE_DYNAMIC
             // Insert the thread right now
-            insert_thread(reconstructed);
+            insert_thread(reconstructed, pathpair.first);
 #endif
             
         }
@@ -818,7 +820,7 @@ void XG::build(map<id_t, string>& node_label,
 #if GPBWT_MODE == MODE_SDSL
         if(is_sorted_dag) {
             // Do the batch insert
-            insert_threads_into_dag(batch, {});
+            insert_threads_into_dag(batch, batch_names);
         }
         // TODO: else case!
 #endif

--- a/src/xg.cpp
+++ b/src/xg.cpp
@@ -3118,16 +3118,19 @@ auto XG::extract_threads_matching(const string& pattern, bool reverse) const -> 
 
 auto XG::extract_threads(bool extract_reverse) const -> map<string, list<thread_t>> {
 
-    // Fill in a lsut of paths found
+    // Fill in a map of lists of paths found by name
     map<string, list<thread_t> > found;
 
 #ifdef VERBOSE_DEBUG
     cerr << "Extracting threads" << endl;
 #endif
+    // We consider "reverse" threads to be those that start on the higher-
+    // numbered sides of their nodes.
+    // We know sides 0 and 1 are unused, so the smallest side is 2.
     int64_t begin = !extract_reverse ? 2 : 3;
-    int64_t end = !extract_reverse ? ts_iv.size() : ts_iv.size()-1;
+    int64_t end = !extract_reverse ? ts_iv.size()-1 : ts_iv.size();
     for(int64_t i = begin; i < end; i+=2) {
-        // For each real side
+        // For every other real side
     
 #ifdef VERBOSE_DEBUG
         cerr << ts_iv[i] << " threads start at side " << i << endl;

--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -271,8 +271,9 @@ public:
     
     // Count matches to a subthread among embedded threads
 
-    /// Insert a thread. Path name must be unique or empty.
-    void insert_thread(const thread_t& t);
+    /// Insert a thread. Name must be unique or empty.
+    /// bs_bake() and tn_bake() need to be called before queries.
+    void insert_thread(const thread_t& t, const string& name);
     /// Insert a whole group of threads. Names should be unique or empty (though
     /// they aren't used yet). The indexed graph must be a DAG, at least in the
     /// subset traversed by the threads. (Reversing edges are fine, but the
@@ -500,6 +501,10 @@ private:
     vlc_vector<> tio_civ; // from thread id to offset / reverse thread id to offset
     // thread starts ordered by their identifiers so we can map from sides into thread ids
     wt_int<> side_thread_wt;
+    
+    // Holds the names of threads while they are being inserted, before the
+    // succinct name representation is built.
+    string names_str;
 
     // A "destination" is either a local edge number + 2, BS_NULL for stopping,
     // or possibly BS_SEPARATOR for cramming multiple Benedict arrays into one.
@@ -526,6 +531,9 @@ private:
     // Prepare the B_s array data structures for query. After you call this, you
     // shouldn't call bset or bs_insert.
     void bs_bake();
+    
+    // Prepare the succinct thread name representation for queries
+    void tn_bake();
 };
 
 class XGPath {


### PR DESCRIPTION
We were not inserting the names of threads created from paths, and we were not checking the very last side for thread starts when extracting threads.