### PR TITLE
Reorder XG member variables initialization

### DIFF
--- a/src/xg.hpp
+++ b/src/xg.hpp
@@ -63,12 +63,12 @@ class XGFormatError : public runtime_error {
 class XG {
 public:
     
-    XG(void) : start_marker('#'),
-               end_marker('$'),
-               seq_length(0),
+    XG(void) : seq_length(0),
                node_count(0),
                edge_count(0),
-               path_count(0) { }
+               path_count(0),
+               start_marker('#'),
+               end_marker('$') { }
     ~XG(void);
     
     // Construct an XG index by loading from a stream. Throw an XGFormatError if


### PR DESCRIPTION
The member variables are initialize in the order which they are
declared. Compiler warns if the order is not followed in the
constructor initialization list causing the compiling fails when
`-Werror` is used.

The order of initialization is simply fixed according to the order
of declaration.